### PR TITLE
Fixed Analog and S/PDIF selectable as Input

### DIFF
--- a/www/inp-config.php
+++ b/www/inp-config.php
@@ -48,9 +48,9 @@ phpSession('close');
 // Input source
 $_select['audio_input'] .= "<option value=\"Local\" " . (($_SESSION['audioin'] == 'Local') ? "selected" : "") . ">MPD</option>\n";
 if ($_SESSION['i2sdevice'] == 'HiFiBerry DAC+ ADC') {
-	$_select['audio_in'] .= "<option value=\"Analog\" " . (($_SESSION['audioin'] == 'Analog') ? "selected" : "") . ">Analog input</option>\n";
+	$_select['audio_input'] .= "<option value=\"Analog\" " . (($_SESSION['audioin'] == 'Analog') ? "selected" : "") . ">Analog input</option>\n";
 } else if ($_SESSION['i2sdevice'] == 'Audiophonics ES9028/9038 DAC' || $_SESSION['i2sdevice'] == 'Audiophonics ES9028/9038 DAC (Pre 2019)') {
-	$_select['audio_in'] .= "<option value=\"S/PDIF\" " . (($_SESSION['audioin'] == 'S/PDIF') ? "selected" : "") . ">S/PDIF input</option>\n";
+	$_select['audio_input'] .= "<option value=\"S/PDIF\" " . (($_SESSION['audioin'] == 'S/PDIF') ? "selected" : "") . ">S/PDIF input</option>\n";
 }
 
 // Resume MPD after changing to Local


### PR DESCRIPTION
Analog and S/PDIF were not selectable due to the pre-refactor array key being used.